### PR TITLE
fix vae decode

### DIFF
--- a/mimogpt/infer/SelftokPipeline.py
+++ b/mimogpt/infer/SelftokPipeline.py
@@ -313,7 +313,7 @@ class SelftokPipeline():
             pred_x0_out = SD3LatentFormat().process_out(pred_x0)
             
             pred_x0_out = pred_x0_out.to(self.dtype)
-            recons = self.vae.decode(pred_x0_out)
+            recons = self.vae.decode(pred_x0_out)[0]
         
         norm_ip(recons, -1, 1)
 


### PR DESCRIPTION
Fixed an issue in the previous implementation where vae.decode() returns a DecoderOutput object, which will lead to an AttributeError: 'DecoderOutput' object has no attribute 'clamp_' at [line 318](https://github.com/selftok-team/SelftokTokenizer/blob/fdc2a7fbe4557785a3903fe1bd85cfde2e84e26b/mimogpt/infer/SelftokPipeline.py#L318).